### PR TITLE
Ensure the commit parent URL doesn’t contain non-SHA characters

### DIFF
--- a/blame_parent.js
+++ b/blame_parent.js
@@ -39,7 +39,7 @@
     sha = shaMatcher.exec( blame.getAttribute('href') )[0];
 
     blame.setAttribute('href', urlTemplate.replace('<SHA>', sha));
-    blameParent.setAttribute('href', urlTemplate.replace('<SHA>', sha + '%5E'));
+    blameParent.setAttribute('href', urlTemplate.replace('<SHA>', sha));
 
     blameParent.innerText = "^";
 


### PR DESCRIPTION
The URL generated for the `^` link had the string `%5E` added to the end, so it gave me a 404 in Github until I removed it.

